### PR TITLE
fix file not found error

### DIFF
--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -151,7 +151,8 @@ if get_gpu():
 
 rule segmentation:
     input:
-        '{output_dir}/final_zarr/{sections}.zarr'
+        '{output_dir}/final_zarr/{sections}.zarr',
+        '{output_dir}/summary_{sections}.yaml'
     output:
        '{output_dir}/masks/{sections}.tiff'
     resources:


### PR DESCRIPTION
added summary yaml was not an input for segmentation rule so it could be found in the get_mem function