### PR TITLE
add cycle registration, expand segments, and best obj step

### DIFF
--- a/workflow/scripts/feature_extraction.py
+++ b/workflow/scripts/feature_extraction.py
@@ -15,6 +15,7 @@ import anndata as ad
 import mudata as md
 import pandas as pd
 import squidpy as sq
+from pathlib import Path
 
 
 
@@ -101,21 +102,35 @@ for m in image.channel.values:
     props = regionprops_table(labels, intensity_image = image.sel(channel = m).values, 
                                   properties = ('intensity_mean',))
     mean_intensity_per_marker.update({m:props['intensity_mean']})
-
-# Make Protein object
 prot_df = pd.DataFrame(data = mean_intensity_per_marker, index = ind, dtype = np.single)
+
+# Measure features inside expanded cell segments
+if len(snakemake.config.get('segmentation').get('expand', {})) > 0: 
+    fname = Path(snakemake.input[1])
+    fname = fname.with_name(f"expanded_{section_name}.tiff")
+    labels = imread(fname)
+    expanded_mean_intensity_per_marker = {}
+    for m in image.channel.values:
+        smk_logger.info(f'Measuring {m} in expanded segment')
+        props = regionprops_table(labels, intensity_image = image.sel(channel = m).values, 
+                                  properties = ('intensity_mean',"label"))
+        expanded_mean_intensity_per_marker.update({f"expanded_{m}":props['intensity_mean']})
+    ind = props["label"]
+    expanded_prot_df = pd.DataFrame(data = expanded_mean_intensity_per_marker, index = ind, dtype = np.single)
+    prot_df = prot_df.join(expanded_prot_df).fillna(0)
+    
 prot_ad = ad.AnnData(X = prot_df)
 
 # Save intensity histograms 
 protein_names = np.array(prot_ad.var.index)
 protein = prot_ad.X
 
-df = pd.DataFrame(columns=['Protein Name', 'Counts', 'Bins'])
-for i, pro in enumerate(protein_names):
-    counts, bins= np.histogram(protein[:,i], bins=20)
-    df.loc[i] = [pro, counts, bins]
+df = pd.DataFrame(index = range(0, 4096-16, 16))
+for i, m in enumerate(image.channel.values):
+    counts, bins= np.histogram(protein[:,i], bins=range(0, 4096, 16))
+    df[m] = counts
 
-df.to_csv(snakemake.output[1], index=False)
+df.to_csv(snakemake.output[1])
 
 feat_dict['protein'] = prot_ad        
 ##########################################################################################
@@ -178,11 +193,16 @@ if len(color_dict.keys()) == 3:
     # Start dask cluster
     # specify default worker options in ~/.config/dask/jobqueue.yaml
     winfo = snakemake.config.get('resources',{}).get('dask_worker',{})
+    # For inference, better to use 1 core with more memory
+    rescale_workers = winfo.get("cores", 1)
+    memory = winfo.get("memory", "16G")
+    winfo["cores"] = 1
+    winfo["memory"] = f"{int(memory.split("G")[0])*rescale_workers}G"
     cluster = get_cluster(**winfo)
     smk_logger.debug(cluster.new_worker_spec())
     smk_logger.info(f'cluster dashboard link:: {cluster.dashboard_link}')
     ntiles = image.col.size//2048
-    nworkers = max(2,ntiles*2*2)
+    nworkers = max(2*rescale_workers,ntiles*2*2)
     smk_logger.info(f'Scale dask cluster to {nworkers}')
     cluster.scale(nworkers)
     client = Client(cluster)
@@ -191,21 +211,26 @@ if len(color_dict.keys()) == 3:
     # Get label bbox and image_filled
     # Might want to do this with regionprops_table
     props = regionprops(labels)
+
     
     #Run cell through imagenet 
     @delayed
-    def get_logits(im, mask, transform, model, px_min = 0, px_max = 4095):
+    def get_logits_batch(cells_data, transform, model, px_min = 0, px_max = 4095):
 
-        mask = np.array([mask]*3)
+        batch_results = []
+        for im, mask_filled in cells_data:
+            mask = np.array([mask_filled]*3)
 
-        im = ((im - px_min)/(px_max-px_min)*255).astype('uint8').values
-        im[~mask] = 0
-        pil = to_pil_image(torch.tensor(im))
-        tensor = (transform(pil)).unsqueeze(0)
-
+            im = ((im - px_min)/(px_max-px_min)*255).astype('uint8').values
+            im[~mask] = 0
+            pil = to_pil_image(torch.tensor(im))
+            tensor = transform(pil)
+            batch_results.append(tensor)
+            
+        batch_tensor = torch.stack(batch_results)
 
         with torch.no_grad():
-            logits = model(tensor).to('cpu').detach().numpy()
+            logits = model(batch_tensor).to('cpu').detach().numpy()
 
         return logits
 
@@ -221,23 +246,34 @@ if len(color_dict.keys()) == 3:
             rmin, cmin, rmax, cmax = props[n].bbox
             cell = im.sel({'row':slice(rmin, rmax), 'col':slice(cmin, cmax)})
 
-
             yield props[n], cell
 
             n += 1
 
+    # Group cells into batches
+    def batch_generator(iterable, size):
+        batch = []
+        for item in iterable:
+            batch.append(item)
+            if len(batch) == size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
             
     # send model/transform to dask workers
     dask_model = client.scatter(model, broadcast=True)
     dask_transform = client.scatter(transform, broadcast=True)
 
-    # Loop through cells and compute imagenet features
+    # Loop through batches of cells and compute imagenet features
+    batch_size = snakemake.config.get('feature_extraction',{}).get('batch_size', 32)
     logit_stack = []
-    for p, c in gen_cells(props, image.sel(channel = markers_)):
-        logits = get_logits(c, p.image_filled, dask_transform, dask_model)
-        logit_stack.append(da.from_delayed(logits, shape = (1,11221), dtype = np.single))    #Shape is only for 1 set of markers
-    imagenet_ = da.concatenate(logit_stack).rechunk() 
-
+    cell_gen = gen_cells(props, image.sel(channel=markers_))
+    for batch in batch_generator(cell_gen, batch_size):
+        cells_batch = [(c, p.image_filled) for p, c in batch]
+        logits = get_logits_batch(cells_batch, dask_transform, dask_model)
+        logit_stack.append(da.from_delayed(logits, shape = (len(batch),11221), dtype = np.single)) 
+    _imagenet = da.concatenate(logit_stack, axis=0)
 
     # delayed_store = features.to_zarr(Path(snakemake.output[1]), compute = False)
                                      
@@ -245,7 +281,7 @@ if len(color_dict.keys()) == 3:
     smk_logger.info(f'Computing imagenet features')
     cluster_report = Path(snakemake.log[0]).with_name(f'features_{image.name}.html')
     with performance_report(filename=cluster_report):
-        imagenet = imagenet_.compute()
+        imagenet = _imagenet.compute()
         
     imagenet_df = pd.DataFrame(data = imagenet, index = ind, columns = [f'{i:05d}' for i in range(11221)], dtype = np.single)
     feat_dict['imagenet'] = ad.AnnData(X = imagenet_df)

--- a/workflow/scripts/picasso.py
+++ b/workflow/scripts/picasso.py
@@ -18,6 +18,13 @@ image = hs_image.im
 smk_logger.debug(image)
 
 # Make sure only 1 objective step
+summary_path = Path(snakemake.input[1])
+with open(summary_path, 'r') as f:
+    summary = yaml.safe_load(f)
+    o = summary.get("best_obj_step", None)
+    if o is not None:
+        image = image.sel(obj_step=o)   
+        
 if 'obj_step' in image.dims:
     if image.obj_step.size > 1:
         mid_step = image.obj_step[image.obj_step.size//2]

--- a/workflow/scripts/preprocess.py
+++ b/workflow/scripts/preprocess.py
@@ -4,11 +4,38 @@ from dask.distributed import Client, wait, performance_report
 from pathlib import Path
 
 
+import xarray as xr
+import dask.array as da
+import numpy as np
+from dask_image.ndinterp import affine_transform
+from skimage.registration import phase_cross_correlation
+import yaml
+import imageio
+from io import BytesIO
+
+def optimal_obj_step(image):
+    im_max = image.max().values
+    im_min = image.min().values
+    image255 = ((image-im_min)/(im_max - im_min)*255).astype("uint8")
+    
+    jpeg_size = []
+    for o in image255.obj_step.values:
+        im = image255.sel(obj_step=o)
+        with BytesIO() as f:
+            imageio.imwrite(f, im, format='jpeg')
+            jpeg_size.append(f.__sizeof__())
+
+    o_ind = np.array(jpeg_size).argmax()
+    
+    return int(image.obj_step[o_ind].values)
+
+
 # Get section name
 section_name = Path(snakemake.input[0]).stem
 
 # Get Processing Options
-focus_projection = exp_dir = snakemake.config.get('preprocess',{}).get('focus projection',False)
+focus_projection = snakemake.config.get('preprocess',{}).get('focus projection',False)
+registration = snakemake.config.get('preprocess',{}).get('registration',{})
 
 # Start logger
 logger = get_logger(logname = section_name, filehandler = snakemake.log[0])
@@ -52,11 +79,69 @@ image.correct_background()
 if focus_projection:
     image.focus_projection()
 image.register_channels()
+
+# Register Cycles
+if len(registration) > 0:
+    cluster.scale(nworkers*2)
+    ref_cy = registration.get("reference_cycle", 0)
+    ref_ch = registration.get("reference_channel", 610)
+    # o = image.im.obj_step[len(image.im.obj_step)//2]
+    ref = image.im.sel(cycle=ref_cy, channel=ref_ch)
+
+    # Find optimal obj_step 
+    o = optimal_obj_step(ref)
+    logger.debug(f"Using obj_step {o} as optimal focus plane")
+    ref = ref.sel(obj_step=o)
+    summary_path = Path(snakemake.output[0]).parents[1] / f"summary_{section_name}.yaml"
+    with open(summary_path, 'r') as f:
+        summary = yaml.safe_load(f)
+    summary["best_obj_step"] = o
+    with open(summary_path, 'w') as f:
+        f.write(yaml.dump(summary))
+    
+    cycles = list(image.im.cycle.values)
+    logger.info(f"Registering cycles against cycle {ref_cy} and {ref_ch} nm channel")
+    
+    def shift_to_affmat(shift):
+        aff_matrix = np.identity(3)
+        aff_matrix[0,2] = -shift[0]
+        aff_matrix[1,2] = -shift[1]
+        return aff_matrix
+    
+    def cycle_affine_transform(im_cy, aff_matrix):
+        ch_stack = []
+    
+        for ch in im_cy.channel:
+            o_stack = []
+            for o in im_cy.obj_step:
+                selection = {"channel":ch, "obj_step":o}
+                o_stack.append(affine_transform(im_cy.sel(**selection).data, aff_matrix))
+            ch_stack.append(da.stack(o_stack))
+                 
+        return xr.DataArray(da.stack(ch_stack), dims=im_cy.dims, coords=im_cy.coords)
+
+    cy_stack = []
+    for cy in cycles:
+        if cy == ref_cy:
+            cy_stack.append(image.im.sel(cycle=cy))
+        else:
+            logger.info(f"Detecting shift in cycle {cy}")
+            shift = phase_cross_correlation(ref, image.im.sel(cycle=cy, channel=ref_ch, obj_step=o), upsample_factor=100)
+            logger.info(f"Cycle {cy}: shift = {shift[0]}, error = {shift[1]}, phasediff = {shift[2]}")
+            aff_matrix = shift_to_affmat(shift[0])
+            cy_stack.append(cycle_affine_transform(image.im.sel(cycle=cy), aff_matrix))
+    registered = xr.concat(cy_stack, dim="cycle")
+    attrs = image.im.attrs
+    image.im = registered
+    image.im.attrs.update(attrs)
+    
+# Remove tiling overlap    
 if snakemake.params.overlap:
     overlap = int(snakemake.params.overlap)
     direction = snakemake.params.direction
     logger.info(f'Remove {overlap} px {direction} overlap')
     image.remove_overlap(overlap = overlap, direction = direction)
+    
 # TODO :: FIX IN pyseq_image 
 image.im.name = section_name
 
@@ -71,7 +156,6 @@ with performance_report(filename=snakemake.log[1]):
     futures = list(future_store.dask.values())
     wait(futures)
 
-
     
 # Double check no errors
 futures_done = [f.done() for f in futures]
@@ -80,14 +164,9 @@ if all(futures_done):
 else:
     logger.info('Error processing images')
 
-    
-
-
-
-    ## some dask computation
-
-
-
+# save attributes
+#with open(save_path.with_suffix('.yaml'), 'w') as f:
+#    yaml.dump(image.im.attrs, f)
 
     
 

--- a/workflow/scripts/segmentation.py
+++ b/workflow/scripts/segmentation.py
@@ -6,6 +6,9 @@ import imageio
 import subprocess
 import numpy as np
 import yaml
+from pathlib import Path
+from scipy.signal import find_peaks
+from skimage.segmentation import watershed
 
 
 # Start logger
@@ -31,10 +34,19 @@ for key in cytoplasm.copy():
         del cytoplasm[key]
 
 if 'obj_step' in image.dims and 'obj_step' not in cytoplasm:
-    if image.obj_step.size > 1:
-        step = image.obj_step[image.obj_step.size - 1]
-        cytoplasm['obj_step'] = step
-        smk_logger.info(f'Using objective step {step}')       
+    summary_path = Path(snakemake.output[0]).parents[1] / f"summary_{section_name}.yaml"
+    with open(summary_path, 'r') as f:
+        summary = yaml.safe_load(f)
+        o = summary.get("best_obj_step", None)
+        
+    if o is not None:
+        cytoplasm['obj_step'] = o
+    elif image.obj_step.size > 1:
+        cytoplasm['obj_step'] = image.obj_step[image.obj_step.size - 1]
+    else:
+        cytoplasm['obj_step'] = image.obj_step[0]
+    
+    smk_logger.info(f'Using objective step {cytoplasm["obj_step"]}')
 
 
 # segment
@@ -123,3 +135,21 @@ with open(snakemake.output[1], 'w') as file:
 
 smk_logger.info('Writing mask')
 imageio.imwrite(snakemake.output[0],masks)
+
+# Expand masks for cell+ segments
+find_peaks_kws = snakemake.config.get('segmentation').get('expand', {})
+if len(find_peaks_kws) > 0: 
+    smk_logger.info('Expanding segments')
+    smk_logger.info(f"{find_peaks_kws}")
+    _im1 = _im1.values
+    # Threshold image so we don't label background
+    counts, bins = np.histogram(_im1.flatten(), bins=range(0, 4097))
+    peaks, props = find_peaks(counts, **find_peaks_kws)
+    mask = _im1 > (peaks[0] + 3*props["widths"][0])
+    # Expand cell segemnts to cover tissue
+    expanded_segments = watershed(-_im1, masks, mask=mask)
+    # Save expanded segments
+    fname = Path(snakemake.output[0])
+    fname = fname.with_name(f"expanded_{section_name}.tiff")
+    imageio.imwrite(fname, expanded_segments)
+

--- a/workflow/snakefile
+++ b/workflow/snakefile
@@ -110,6 +110,10 @@ rule fix_lighting:
     log:
         '{output_dir}/logs/fixlighting_{sections}.log',
         '{output_dir}/logs/fixlighting_{sections}.html'
+    threads: 8
+    resources: 
+        mem_mb = get_mem,
+        runtime = get_picasso_time
     output:
         directory('{output_dir}/processed_zarr/{sections}.zarr'),
     conda:
@@ -198,7 +202,7 @@ rule feature_extraction:
         '{output_dir}/features/{sections}.h5mu',
         '{output_dir}/features/{sections}.csv'
     log: 
-        '{output_dir}/logs/intensity_{sections}.log'
+        '{output_dir}/logs/features_{sections}.log'
     threads: 8
     resources:
         mem_mb = get_mem,


### PR DESCRIPTION
Add best obj step:
  look through obj stacks to find plane most in focus. Use it for registration and segmentation

Add cycle registration in fix_lighting:
  use phase cross correlation with sub sampling to align across cycles

Expand cell segments:
  Watershed cellpose segments to create segments that cover the entire tissue
  Imagenet features computed from expanded segments
  Also compute mean intensity within expanded segments

Fix cell instensity histograms
  histograms were saved csv with counts and bins save as plain text, not arrays
  Now saved with first column as bins and subsequent columns as counts of cells with mean expression in the those bins

